### PR TITLE
Update Faker method call.

### DIFF
--- a/test/fixtures/entries.yml
+++ b/test/fixtures/entries.yml
@@ -32,7 +32,7 @@ green:
 <% 30.times do |n| %>
 entry_<%= n %>:
   date: <%= Date.jd(2_456_000 + Random.rand(1000)).to_s %>
-  content: <%= Faker::Lorem.sentence(5) %>
+  content: <%= Faker::Lorem.sentence(word_count: 5) %>
   mileage: 197_000
   employee: 'Mike'
   equipment: ford


### PR DESCRIPTION
Change call in test fixtures for random lorem sentences to include the new argument for word count. Previously could just pass an integer, now have to pass a key/value pair.